### PR TITLE
- fixed minor bug with context path not being part of the url when cr…

### DIFF
--- a/grails-app/taglib/org/grails/plugin/springsecurity/saml/SamlTagLib.groovy
+++ b/grails-app/taglib/org/grails/plugin/springsecurity/saml/SamlTagLib.groovy
@@ -52,7 +52,7 @@ class SamlTagLib extends SecurityTagLib {
         def elementClass = generateClassAttribute(attrs)
         def elementId = generateIdAttribute(attrs)
 
-        out << "<a href='${url}'${elementId}${elementClass}>${body()}</a>"
+        out << "<a href='${contextPath}${url}'${elementId}${elementClass}>${body()}</a>"
     }
 
     /**


### PR DESCRIPTION
Sorry I choose master since develop seems to be for grails 3-4 and this PR is in relation to Grails 5. 
Very minor issue I noticed with the sec.loginLink not adding context path when building the login url for authentication. I hope I did this right for my first time!